### PR TITLE
Add mod command for adjusting delta

### DIFF
--- a/Configuration.cs
+++ b/Configuration.cs
@@ -11,6 +11,7 @@ namespace PennyPincher
 
         public bool alwaysOn { get; set; } = false;
         public int delta { get; set; } = 1;
+        public int mod { get; set; } = 1;
         public bool smart { get; set; } = true;
         public bool verbose { get; set; } = true;
 

--- a/PennyPincher.json
+++ b/PennyPincher.json
@@ -3,7 +3,7 @@
   "Name": "Penny Pincher",
   "Description": "Copies 1 below the cheapest offer to your clipboard when you check marketboard prices. /penny help",
   "InternalName": "PennyPincher",
-  "AssemblyVersion": "1.2.0.0",
+  "AssemblyVersion": "1.2.0.1",
   "RepoUrl": "https://github.com/tesu/PennyPincher",
   "ApplicableVersion": "any",
   "Tags": ["marketboard", "undercut", "penny", "clipboard"],

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -18,6 +18,7 @@ namespace PennyPincher
         private const string commandName = "/penny";
         private const string helpName = "help";
         private const string deltaName = "delta";
+        private const string modName = "mod";
         private const string smartName = "smart";
         private const string verboseName = "verbose";
 
@@ -83,6 +84,7 @@ namespace PennyPincher
                 case helpName:
                     this.pi.Framework.Gui.Chat.Print($"{commandName}: Toggles whether {Name} is always on (supersedes {smartName})");
                     this.pi.Framework.Gui.Chat.Print($"{commandName} {deltaName} <delta>: Sets the undercutting amount to be <delta>");
+                    this.pi.Framework.Gui.Chat.Print($"{commandName} {modName} <mod>: Adjusts base price by subtracting <price> % <mod> from <price> before subtracting <delta>. This makes the last digits of your posted prices consistent.");
                     this.pi.Framework.Gui.Chat.Print($"{commandName} {smartName}: Toggles whether {Name} should automatically copy when you're using a retainer");
                     this.pi.Framework.Gui.Chat.Print($"{commandName} {verboseName}: Toggles whether {Name} prints whenever it copies to clipboard");
                     this.pi.Framework.Gui.Chat.Print($"{commandName} {helpName}: Displays this help page");
@@ -92,6 +94,28 @@ namespace PennyPincher
                     this.configuration.Save();
                     PrintSetting($"{Name}", this.configuration.alwaysOn);
                     this.pi.Framework.Gui.Chat.Print($"Note that \"{commandName} alwayson\" has been renamed to \"{commandName}\".");
+                    return;
+                case modName:
+                    if (argArray.Length < 2)
+                    {
+                        this.pi.Framework.Gui.Chat.Print($"{commandName} {modName} missing <mod> argument.");
+                        return;
+                    }
+                    var a = argArray[1];
+                    try
+                    {
+                        this.configuration.mod = int.Parse(a);
+                        this.configuration.Save();
+                        this.pi.Framework.Gui.Chat.Print($"{Name} {modName} set to {this.configuration.mod}.");
+                    }
+                    catch (FormatException)
+                    {
+                        this.pi.Framework.Gui.Chat.Print($"Unable to read '{a}' as an integer.");
+                    }
+                    catch (OverflowException)
+                    {
+                        this.pi.Framework.Gui.Chat.Print($"'{a}' is out of range.");
+                    }
                     return;
                 case deltaName:
                     if (argArray.Length < 2)
@@ -158,7 +182,7 @@ namespace PennyPincher
                 if (i == listing.ItemListings.Count) return;
             }
 
-            var price = listing.ItemListings[i].PricePerUnit - this.configuration.delta;
+            var price = listing.ItemListings[i].PricePerUnit - (listing.ItemListings[i].PricePerUnit % this.configuration.mod) - this.configuration.delta;
             Clipboard.SetText(price.ToString());
             if (this.configuration.verbose) {
                 if (isCurrentItemHQ)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ This both speeds up the process and reduces room for error from typos/missing di
 |---------|-------------|---------|
 |`/penny`|Toggles whether to always copy prices. Supercedes the `smart` setting. |disabled|
 |`/penny delta <delta>`|Sets how much to undercut by. A delta of 0 would copy the same price as the lowest offer, and a delta of 100 would copy 100 under the lowest offer. Negative numbers work exactly how you would expect, though it's not obvious to me how this could be useful.|1|
+|`/penny mod <mod>`|Adjusts base price by subtracting <price> % <mod> from <price> before subtracting <delta>. This makes the last digits of your posted prices consistent.|1|
 |`/penny smart`|Toggles whether to always copy prices when accessing the marketboard from a retainer.|enabled|
 |`/penny verbose`|Toggles whether to print to chat when a price to copied.|enabled|
 |`/penny help`|Displays the list of commands.||
 
 ## Changelog
+1.2.0.1: `/penny mod` added
 1.2.0.0: `/penny hq` has been replaced with smarter behavior (checking if the item you're listing is HQ or not)  
 1.1.0.0: `/penny alwayson` has been renamed to `/penny`


### PR DESCRIPTION
I like to have all my prices posted ending with the same value. This feature adds another command, mod, which enables a simple modulo subtraction from the current price so that the last few digits of the price are floored to 0 and allow more consistent prices for your own (regardless of what other people are posting).

Mod defaults to 1, so the normal behavior remains if people don't want to use this.

Example:
PricePerUnit = 65999
Mod = 1000
Delta = 464
65999 - (65999 % 1000) = 65000 - 464 = 64536