### PR TITLE
Minimal updates for API 6

### DIFF
--- a/PennyPincher.cs
+++ b/PennyPincher.cs
@@ -82,7 +82,6 @@ namespace PennyPincher
             PluginInterface.UiBuilder.Draw -= DrawWindow;
             PluginInterface.UiBuilder.OpenConfigUi -= OpenConfigUi;
             CommandManager.RemoveHandler(commandName);
-            PluginInterface.Dispose();
         }
         
         private void Command(string command, string arguments)

--- a/PennyPincher.csproj
+++ b/PennyPincher.csproj
@@ -11,7 +11,7 @@
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <OutputPath>bin\$(Configuration)\</OutputPath>
-    <AssemblyVersion>1.4.0.2</AssemblyVersion>
+    <AssemblyVersion>1.4.0.3</AssemblyVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -31,7 +31,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.2" />
+    <PackageReference Include="DalamudPackager" Version="2.1.6" />
     <Reference Include="Dalamud">
       <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
       <Private>false</Private>

--- a/PennyPincher.json
+++ b/PennyPincher.json
@@ -7,6 +7,5 @@
     "Tags": [ "marketboard", "undercut", "penny", "clipboard" ],
     "ImageUrls": [],
     "IconUrl": "https://github.com/tesu/PennyPincher/raw/master/images/icon.png",
-    "Changelog": "Brings back /penny hq, by popular demand.",
-    "DalamudApiLevel": 5
+    "Changelog": "Updated for API 6"
 }


### PR DESCRIPTION
- Bump DalamudPackager to verion 2.1.6
- Remove API level override from json (DP will handle that for you)
- Remove unneeded Dispose line. (Dalamud has deprecated disposing the plugin interface for each plugin)