### PR TITLE
Undercut NQ prices for NQ item & HQ prices for HQ item

### DIFF
--- a/PennyPincher.csproj
+++ b/PennyPincher.csproj
@@ -54,6 +54,10 @@
       <HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="FFXIVClientStructs">
+      <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
Detects whether an item is NQ or HQ when opening the "Adjust Price" window, and undercuts NQ prices when selling a NQ item/HQ prices when selling a HQ item.

- When "Undercut HQ prices" is checked, this has no effect and will retain the old behavior (it'll always undercut HQ prices), but it may be worth considering removing that config option
- Shift still works as a toggle for NQ prices on HQ items / HQ prices on NQ items