### PR TITLE
Don't undercut own retainers if they're the cheapest offer

### DIFF
--- a/PennyPincher.cs
+++ b/PennyPincher.cs
@@ -247,17 +247,18 @@ namespace PennyPincher
             var i = 0;
             if (useHq && items.Single(j => j.RowId == listing.ItemListings[0].CatalogId).CanBeHq)
             {
-                while (i < listing.ItemListings.Count && !listing.ItemListings[i].IsHq) i++;
-                if (i == listing.ItemListings.Count) return;
+                while (i < listing.ItemListings.Count && (!listing.ItemListings[i].IsHq || IsOwnRetainer(listing.ItemListings[i].RetainerId))) i++;
+            }
+            else
+            {
+                while (i < listing.ItemListings.Count && IsOwnRetainer(listing.ItemListings[i].RetainerId)) i++;
             }
 
-            long price = listing.ItemListings[i].PricePerUnit;
-            if (!IsOwnRetainer(listing.ItemListings[i].RetainerId))
-            {
-                price = price - (listing.ItemListings[i].PricePerUnit % configuration.mod) - configuration.delta;
-                price -= (price % configuration.multiple);
-                price = Math.Max(price, configuration.min);
-            }
+            if (i == listing.ItemListings.Count) return;
+
+            var price = listing.ItemListings[i].PricePerUnit - (listing.ItemListings[i].PricePerUnit % configuration.mod) - configuration.delta;
+            price -= (price % configuration.multiple);
+            price = Math.Max(price, configuration.min);
 
             ImGui.SetClipboardText(price.ToString());
             if (configuration.verbose)

--- a/PennyPincher.cs
+++ b/PennyPincher.cs
@@ -12,6 +12,7 @@ using Dalamud.Game.Network.Structures;
 using Dalamud.IoC;
 using Dalamud.Logging;
 using Dalamud.Plugin;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
 using Lumina.Excel.GeneratedSheets;
 using Num = System.Numerics;
@@ -244,9 +245,14 @@ namespace PennyPincher
                 if (i == listing.ItemListings.Count) return;
             }
 
-            var price = listing.ItemListings[i].PricePerUnit - (listing.ItemListings[i].PricePerUnit % configuration.mod) - configuration.delta;
-            price -= (price % configuration.multiple);
-            price = Math.Max(price, configuration.min);
+            long price = listing.ItemListings[i].PricePerUnit;
+            if (!IsOwnRetainer(listing.ItemListings[i].RetainerId))
+            {
+                price = price - (listing.ItemListings[i].PricePerUnit % configuration.mod) - configuration.delta;
+                price -= (price % configuration.multiple);
+                price = Math.Max(price, configuration.min);
+            }
+
             ImGui.SetClipboardText(price.ToString());
             if (configuration.verbose)
             {
@@ -268,6 +274,20 @@ namespace PennyPincher
             var neededItems = listing.ListingIndexStart + listing.ItemListings.Count;
             var actualItems = _cache.Sum(x => x.ItemListings.Count);
             return (neededItems == actualItems);
+        }
+
+        private unsafe bool IsOwnRetainer(ulong retainerId)
+        {
+            var retainerManager = RetainerManager.Instance();
+            for (int i = 0; i < retainerManager->GetRetainerCount(); ++i)
+            {
+                if (retainerId == retainerManager->Retainer[i]->RetainerID)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/PennyPincher.csproj
+++ b/PennyPincher.csproj
@@ -54,6 +54,10 @@
       <HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="FFXIVClientStructs">
+      <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
   </ItemGroup>
 
   <Target Name="PackagePlugin" AfterTargets="Build" Condition="'$(Configuration)' == 'Release'">


### PR DESCRIPTION
Don't undercut if the first found, cheapest market board offer is from your own retainer.

This will undercut if your own + another player's retainer offer the same price only if your own retainer is second in the market board listing; it should be relatively easy to build some logic for that if needed.