### PR TITLE
chore: remove drunken toad

### DIFF
--- a/PennyPincher.cs
+++ b/PennyPincher.cs
@@ -292,7 +292,7 @@ namespace PennyPincher
                 // clear cache on new request so we can verify that we got all the data we need when we inspect the price
                 _cache.Clear();
 
-                var shiftHeld = KeyState[(byte)Dalamud.DrunkenToad.ModifierKey.Enum.VkShift];
+                var shiftHeld = KeyState[VirtualKey.SHIFT];
                 useHq = shiftHeld ^ (configuration.hq && itemHq);
             }
             if (packetType != PennyPincherPacketType.MarketBoardOfferings || !newRequest) return;

--- a/PennyPincher.csproj
+++ b/PennyPincher.csproj
@@ -37,7 +37,6 @@
 
   <ItemGroup>
     <PackageReference Include="DalamudPackager" Version="2.1.10" />
-    <PackageReference Include="Dalamud.DrunkenToad" Version="1.5.6" />
     <Reference Include="Dalamud">
       <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
       <Private>false</Private>

--- a/packages.lock.json
+++ b/packages.lock.json
@@ -2,25 +2,11 @@
   "version": 1,
   "dependencies": {
     "net7.0-windows7.0": {
-      "Dalamud.DrunkenToad": {
-        "type": "Direct",
-        "requested": "[1.5.6, )",
-        "resolved": "1.5.6",
-        "contentHash": "AMkUXOWliSg1I6RkmD7tEDxrpRlhnSPF3bmkynDSA4W+Mjf/Ps4+9NiUHhiiplrd+iBgWlRyT7lzs0Zj4NDETA==",
-        "dependencies": {
-          "LiteDB": "5.0.11"
-        }
-      },
       "DalamudPackager": {
         "type": "Direct",
         "requested": "[2.1.10, )",
         "resolved": "2.1.10",
         "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
-      },
-      "LiteDB": {
-        "type": "Transitive",
-        "resolved": "5.0.11",
-        "contentHash": "6cL4bOmVCUB0gIK+6qIr68HeqjjHZicPDGQjvJ87mIOvkFsEsJWkIps3yoKNeLpHhJQur++yoQ9Q8gxsdos0xQ=="
       }
     }
   }


### PR DESCRIPTION
Hi there! I recently finished refactoring Dalamud.DrunkenToad as part of an overhaul on one of my own plugins. I wanted to help others with active plugins so I'm raising PRs to fix any upgrade issues. In your case, you were only using the library for the KeyState enum which has been since moved to Dalamud. So I just updated your code to use that and dropped the library.